### PR TITLE
[Port]: Update to Latest Beacon API

### DIFF
--- a/repository/Chrome-Core.package/ChromeFrameLoadingProcessor.class/instance/ensureIdleTimer.st
+++ b/repository/Chrome-Core.package/ChromeFrameLoadingProcessor.class/instance/ensureIdleTimer.st
@@ -8,7 +8,7 @@ ensureIdleTimer
 	idleProcess := [ | done timeDiff frameLoaded |
 		ChromeIdleTimerSignal new
 			message: 'Started idle timer';
-			log.
+			emit.
 		done := false.
 		[ done ] whileFalse:
 			[ (Delay forMilliseconds: 500) wait.
@@ -17,22 +17,22 @@ ensureIdleTimer
 				message: 'Checking';
 				loadedTimestamp: loadedTimestamp;
 				frameLoaded: frameLoaded;
-				log.
+				emit.
 			(loadedTimestamp isNotNil and: [ frameLoaded ]) ifTrue: [
 				timeDiff := (DateAndTime now - loadedTimestamp) asMilliSeconds.
 				ChromeIdleTimerSignal new 
 					message: 'timeDiff';
 					timeDiff: timeDiff;
-					log.
+					emit.
 		 		timeDiff >= pageLoadDelay ifTrue:
 					[ done := true.
 					ChromeIdleTimerSignal new
 						message: 'Signalling';
-						log.
+						emit.
 					semaphore signal. ]
 				]
 			].
 		ChromeIdleTimerSignal new 
 			message: 'Idle Timer Done';
-			log.
+			emit.
 		] forkNamed: 'Chrome Idle Timer'

--- a/repository/Chrome-Core.package/ChromeStringSignal.class/class/log.category..st
+++ b/repository/Chrome-Core.package/ChromeStringSignal.class/class/log.category..st
@@ -3,4 +3,4 @@ log: aString category: aCategory
 	^ self new 
 		message: aString;
 		category: aCategory;
-		log
+		emit

--- a/repository/Chrome-Core.package/GoogleChrome.class/class/exampleNavigation.st
+++ b/repository/Chrome-Core.package/GoogleChrome.class/class/exampleNavigation.st
@@ -2,7 +2,7 @@ examples
 exampleNavigation
 	| chrome page logger |
 
-	logger := InMemoryLogger new.
+	logger := MemoryLogger new.
 	logger start.
 	chrome := GoogleChrome new
             debugOn;


### PR DESCRIPTION
1. Beacon has renamed `InMemoryLogger` to `MemoryLogger`
2. I guess Beacon has renamed `#log` to `#emit`