### PR TITLE
additions and FreeBSD fixes

### DIFF
--- a/repository/Chrome-Core.package/ChromeMessageProcessor.class/instance/wait.st
+++ b/repository/Chrome-Core.package/ChromeMessageProcessor.class/instance/wait.st
@@ -1,5 +1,5 @@
 messages
 wait
-	"Wait for the receivers message to be processed"
+	"Wait for the receivers message to be processed (with timeout)"
 
-	semaphore wait
+	semaphore waitTimeoutSeconds: 180 onCompletion: nil onTimeout: [ Error signal: 'Google Chrome Message Processor timeout' ].

--- a/repository/Chrome-Core.package/ChromeNode.class/instance/hasClass..st
+++ b/repository/Chrome-Core.package/ChromeNode.class/instance/hasClass..st
@@ -1,0 +1,3 @@
+testing
+hasClass: aClassNameString
+	^ (((self attributeAt: 'class' ifAbsent: [ '' ]) substrings: ' ') collect: [ :s | s trim ]) includes: aClassNameString.

--- a/repository/Chrome-Core.package/GoogleChrome.class/class/getHeadless..st
+++ b/repository/Chrome-Core.package/GoogleChrome.class/class/getHeadless..st
@@ -1,0 +1,5 @@
+instance creation
+getHeadless: anURL
+	"Answer the ChromeNode of the requested page - headless"
+
+	^ self new headless: true; get: anURL

--- a/repository/Chrome-Core.package/UnixChromePlatform.class/class/defaultExecutableLocation.st
+++ b/repository/Chrome-Core.package/UnixChromePlatform.class/class/defaultExecutableLocation.st
@@ -1,5 +1,4 @@
 defaults
 defaultExecutableLocation
-
-	^#('/opt/google/chrome/chrome' '/usr/bin/chromium-browser') detect:
+	^ #('/opt/google/chrome/chrome' '/usr/bin/chromium-browser' '/usr/local/share/chromium/chrome') detect:
 		[ :each | each asFileReference exists ].


### PR DESCRIPTION
- modified processor wait method (added timeout)
On FreeBSD (maybe on other platforms), Chrome is not functioning 100% stable, threre is crashes and hangs. When background Chrome process hangs, original semaphore wait method waits forever - I added default 3 minutes timeout (excepion is sigaled after this timeout) - this solves hanging problem - are you OK with this? some comments?

- new css class testing method in ChromeNode class
Good for finding tags with specific css class

- utility headless class method in GoogleChrome class 
Simple to use headless get method (just like original get method)

- added Chrome executable location for FreeBSD